### PR TITLE
Active storageを使用してユーザーのプロフィール画像を投稿できるようにしました。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "jbuilder", "~> 2.7"
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 gem "awesome_print"
 gem "rails-i18n"
 # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,11 @@ gem "jbuilder", "~> 2.7"
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-gem 'image_processing', '~> 1.2'
+gem "image_processing", "~> 1.2"
 gem "awesome_print"
 gem "rails-i18n"
+gem "mini_magick", ">= 4.9.5"
+gem "active_storage_validations"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.2", require: false
 gem "carrierwave"
@@ -61,6 +63,7 @@ group :development do
   gem "faker"
   gem "better_errors"
   gem "binding_of_caller"
+  gem "bullet"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_storage_validations (0.9.0)
+      rails (>= 5.2.0)
     activejob (6.0.3.2)
       activesupport (= 6.0.3.2)
       globalid (>= 0.3.6)
@@ -79,6 +81,9 @@ GEM
     bootsnap (1.4.7)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.33.0)
       addressable
@@ -306,6 +311,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    uniform_notifier (1.13.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (4.0.4)
@@ -332,10 +338,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_storage_validations
   awesome_print
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.2)
+  bullet
   byebug
   capybara (>= 2.15)
   carrierwave
@@ -352,6 +360,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.2)
+  mini_magick (>= 4.9.5)
   omniauth
   omniauth-github
   puma (~> 4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,6 +348,7 @@ DEPENDENCIES
   faker
   font-awesome-sass
   html-pipeline
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,3 +39,7 @@
 .card-body{
   color: #696969;  
 }
+// .image_tag {
+//   border-radius: 50%; 
+//   background-color:red;
+// }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,7 +39,4 @@
 .card-body{
   color: #696969;  
 }
-// .image_tag {
-//   border-radius: 50%; 
-//   background-color:red;
-// }
+

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -10,7 +10,7 @@ class BooksController < ApplicationController
       @user = User.find(params[:user_id]) # これで現在ログイン中の自分のものが表示できる。
       @books = @user.books.page(params[:page]).recent.per(Constants::DISPLAYABLE_USER_SIZE)
     else
-      @books = Book.includes(:user).page(params[:page]).recent.per(Constants::DISPLAYABLE_USER_SIZE)
+      @books = Book.eager_load(:user).page(params[:page]).recent.per(Constants::DISPLAYABLE_USER_SIZE)
     end
   end
 

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -10,7 +10,7 @@ class BooksController < ApplicationController
       @user = User.find(params[:user_id]) # これで現在ログイン中の自分のものが表示できる。
       @books = @user.books.page(params[:page]).recent.per(Constants::DISPLAYABLE_USER_SIZE)
     else
-      @books = Book.all.page(params[:page]).recent.per(Constants::DISPLAYABLE_USER_SIZE)
+      @books = Book.includes(:user).page(params[:page]).recent.per(Constants::DISPLAYABLE_USER_SIZE)
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
     end
 
     def user_params
-      params.require(:user).permit(:email, :name, :zip_code, :address, :introduction)
+      params.require(:user).permit(:email, :name, :zip_code, :address, :introduction, :portrait)
     end
 
     def correct_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,5 @@ class User < ApplicationRecord
   validates :address, length: { maximum: 80 }
   validates :introduction, length: { maximum: 500 }
   validates :zip_code,  length: { maximum: 10 }
+  has_one_attached :portrait
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_one_attached :portrait
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i(github)
 
@@ -26,5 +28,5 @@ class User < ApplicationRecord
   validates :address, length: { maximum: 80 }
   validates :introduction, length: { maximum: 500 }
   validates :zip_code,  length: { maximum: 10 }
-  has_one_attached :portrait
+  validates :portrait, attached: true, content_type: ["image/png", "image/jpg", "image/jpeg"]
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,5 +28,5 @@ class User < ApplicationRecord
   validates :address, length: { maximum: 80 }
   validates :introduction, length: { maximum: 500 }
   validates :zip_code,  length: { maximum: 10 }
-  validates :portrait, attached: true, content_type: ["image/png", "image/jpg", "image/jpeg"]
+  validates :portrait, content_type: ["image/png", "image/jpg", "image/jpeg"]
 end

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -31,6 +31,8 @@
         <% if current_user && current_user.id == book.user.id %>
           <td><button type="button" class="btn btn-outline-info btn-sm"><%= link_to t("link.Edit"), edit_book_path(book) %></button></td>
           <td><button type="button" class="btn btn-outline-danger btn-sm"><%= link_to t("link.Destroy"), book, method: :delete, data: { confirm: t("modal.confirm") } %></button></td>
+        <% else %>
+        <td></td><td></td>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -38,6 +38,11 @@
     <%= form.text_area :introduction, autofocus: true, class: "form-control", autocomplete: "introduction" %>
   </div>
 
+   <div class="field">
+    <%= form.label :portrait %>
+    <%= form.file_field :portrait,direct_upload: true %>
+  </div>
+
   <div class="actions">
     <%= form.submit class: "btn btn-primary " %>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -40,7 +40,8 @@
 
    <div class="field">
     <%= form.label :portrait %>
-    <%= form.file_field :portrait,direct_upload: true %>
+    <%= form.file_field :portrait, direct_upload: true %>
+    <small class="form-text text-muted"><%= t(".Please_use_one_of_'png'_'jpg'_or_'jpeg'_for_portrait_file_format.") %></small>
   </div>
 
   <div class="actions">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
-<%if @user.portrait.attached?%>
-  <p><strong>Portrait:<div class = "image_tag"><%= image_tag @user.portrait.variant(resize_to_limit:[400,400])%>
+<% if @user.portrait.attached? %>
+  <p><strong><%= t (".Portrait") %><div class="image_tag"><%= image_tag @user.portrait.variant(resize_to_limit: [400, 400]) %>
   </div></strong></p>
-<%end%> 
+<% end %>
 
 <p><h1><strong><%= User.human_attribute_name(:name) %> :</strong><%= "#{@user.name}" %></h1></p>
 <p><strong><%= User.human_attribute_name(:email) %> :</strong> <%= @user.email %></p>
@@ -11,6 +11,6 @@
 <p><strong><%= t(".Number of books posted") %>：</strong><%= @book_count %><p>
 
 <% if current_user == @user %>
-  <%= link_to t("directory.link.Edit"), edit_user_path(@user) %> |
-  <%= link_to "Edit password", edit_user_registration_path, class: "navbar-link" %>
+  <%= link_to t("link.Edit"), edit_user_path(@user) %> |
+  <%= link_to t("link.Edit password"), edit_user_registration_path, class: "navbar-link" %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,8 @@
+<%if @user.portrait.attached?%>
+  <p><strong>Portrait:<div class = "image_tag"><%= image_tag @user.portrait.variant(resize_to_limit:[400,400])%>
+  </div></strong></p>
+<%end%> 
+
 <p><h1><strong><%= User.human_attribute_name(:name) %> :</strong><%= "#{@user.name}" %></h1></p>
 <p><strong><%= User.human_attribute_name(:email) %> :</strong> <%= @user.email %></p>
 <p><strong><%= User.human_attribute_name(:address) %>  :</strong> <%= @user.address %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,6 +8,13 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
+  config.after_initialize do
+    Bullet.enable = true # Bulletプラグインを有効
+    Bullet.alert = true # JavaScriptでの通知
+    Bullet.bullet_logger = true # log/bullet.logへの出力
+    Bullet.console = true # ブラウザのコンソールログに記録
+    Bullet.rails_logger = true # Railsログに出力
+  end
   # Do not eager load code on boot.
   config.eager_load = false
 

--- a/config/locales/defaults/ja.yml
+++ b/config/locales/defaults/ja.yml
@@ -6,6 +6,7 @@ ja:
     Destroy: 削除
     Top: トップページへ戻る
     Logout: ログアウト
+    Edit password: パスワードを変更
   flash:
     destroy: 削除しました！
     create: 作成しました！

--- a/config/locales/views/users/ja.yml
+++ b/config/locales/views/users/ja.yml
@@ -29,13 +29,16 @@ ja:
         address: 住所
         zip_code: 郵便番号
         introduction: 自己紹介文
+        portrait: プロフィール画像
     models:
       user: ユーザー
   users:
     show:
       Number of books posted: 投稿した本の件数
+      Portrait: プロフィール画像
     edit:
       Editing User: プロフィールの編集
+      Please_use_one_of_'png'_'jpg'_or_'jpeg'_for_portrait_file_format: プロフィール画像のファイル形式は'png', 'jpg', 'jpeg' のいずれかを使用してください。
     confirmations:
       confirmed: メールアドレスが確認できました。
       new:
@@ -145,6 +148,7 @@ ja:
       expired: の有効期限が切れました。新しくリクエストしてください。
       not_found: は見つかりませんでした。
       not_locked: は凍結されていません。
+      content_type_invalid: "のファイル形式は'png', 'jpg', 'jpeg' のいずれかを使用してください。"
       not_saved:
         one: エラーが発生したため %{resource} は保存されませんでした。
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/db/migrate/20200902115108_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200902115108_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20200902115108_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200902115108_create_active_storage_tables.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_09_02_115108) do
-
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_30_064940) do
+ActiveRecord::Schema.define(version: 2020_09_02_115108) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
   create_table "books", force: :cascade do |t|
     t.string "title", null: false
     t.text "memo"
@@ -42,4 +62,6 @@ ActiveRecord::Schema.define(version: 2020_08_30_064940) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,8 +12,6 @@
                )
 end
 
-# title = Faker::Book.title
-# author = Faker::Book.author
 User.all.each do |user|
   3.times do |n|
     title = Faker::Book.title


### PR DESCRIPTION
### 具体的な変更点
Active storageを使用してプロフィール画像を投稿表示できるようにしました。
バリーデーションで画像のタイプは”png", "jpg", "jpeg”のみ許可しています。

### どのように実装したか
バリデーションはgem "active_storage_validations"を使用して実装しました。

### 他に知らせたい事
課題とは直接関係ないですが、gem "bullet"を使いN+1問題の発生を見落とさないようにしました。
見た目や翻訳も若干修正しました。

### ユーザープロフィールページの画像
![image](https://user-images.githubusercontent.com/64201542/92298431-a4a12580-ef83-11ea-922e-e3b7b330a164.png)

